### PR TITLE
Add multiplayer game state management improvements

### DIFF
--- a/src/pages/GameMenu.vue
+++ b/src/pages/GameMenu.vue
@@ -351,9 +351,7 @@ const handleStartGame = () => {
     if (multiplayerRole.value === "join") {
       setTimeout(() => {
         const store = useGameStore()
-        const state = JSON.parse(JSON.stringify(store.gameState))
-        state.players[1].name = player2Name.value.trim() || t("player2")
-        setGameState(multiplayerCode.value, state)
+        store.updateJoiningPlayerName(player2Name.value.trim() || t("player2"))
       }, 300)
     }
     localStorage.setItem("multiplayerRole", multiplayerRole.value)

--- a/src/pages/GameMenu.vue
+++ b/src/pages/GameMenu.vue
@@ -204,7 +204,6 @@
 import { ref, watch } from "vue"
 import { useRouter } from "vue-router"
 import { useGameStore } from "../stores/gameStore"
-import { setGameState } from "../utils/firebase"
 import { useI18n } from "../i18n"
 import SelectorButton from "../components/SelectorButton.vue"
 import BaseButton from "../components/BaseButton.vue"

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -2,7 +2,28 @@ import { defineStore } from "pinia"
 import { ref, computed, watch } from "vue"
 import type { GameState } from "../types/game"
 import { useI18n } from "../i18n"
-import { useGameState, setGameState } from "../utils/firebase"
+import { useGameState, setGameState, updateGameState } from "../utils/firebase"
+
+// Add new function
+function canModifyGameState() {
+  if (!multiplayer.value) return true
+  
+  if (multiplayer.value.role === "host") {
+    return gameState.value.currentPlayer === 0
+  } else {
+    return gameState.value.currentPlayer === 1
+  }
+}
+
+// Add new function
+function updateJoiningPlayerName(name: string) {
+  if (!multiplayer.value || multiplayer.value.role !== "join") return
+  
+  const code = multiplayer.value.code
+  updateGameState(code, {
+    "players/1/name": name,
+  })
+}
 
 // Constants moved outside the store
 const MIN_QUALIFYING_SCORE_OPTIONS = [500, 750, 1000]
@@ -1360,17 +1381,19 @@ export const useGameStore = defineStore("game", () => {
     if (multiplayer.value && multiplayer.value.unbind)
       multiplayer.value.unbind()
     multiplayer.value = { code, role: "host" }
-    // Save game state to Firebase whenever it changes
+    
+    setGameState(code, gameState.value)
+    
     const stop = watch(
       gameState,
       (val) => {
-        setGameState(code, val)
+        if (canModifyGameState() || showMenu.value) {
+          setGameState(code, val)
+        }
       },
       { deep: true }
     )
     multiplayer.value.unbind = stop
-    // Initial push
-    setGameState(code, gameState.value)
   }
 
   function joinMultiplayerGame(code: string) {
@@ -1457,5 +1480,7 @@ export const useGameStore = defineStore("game", () => {
     joinMultiplayerGame,
     leaveMultiplayerGame,
     multiplayer,
+    updateJoiningPlayerName,
+    canModifyGameState,
   }
 })

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -4,27 +4,6 @@ import type { GameState } from "../types/game"
 import { useI18n } from "../i18n"
 import { useGameState, setGameState, updateGameState } from "../utils/firebase"
 
-// Add new function
-function canModifyGameState() {
-  if (!multiplayer.value) return true
-  
-  if (multiplayer.value.role === "host") {
-    return gameState.value.currentPlayer === 0
-  } else {
-    return gameState.value.currentPlayer === 1
-  }
-}
-
-// Add new function
-function updateJoiningPlayerName(name: string) {
-  if (!multiplayer.value || multiplayer.value.role !== "join") return
-  
-  const code = multiplayer.value.code
-  updateGameState(code, {
-    "players/1/name": name,
-  })
-}
-
 // Constants moved outside the store
 const MIN_QUALIFYING_SCORE_OPTIONS = [500, 750, 1000]
 const WINNING_SCORE = 10000
@@ -271,6 +250,27 @@ export const useGameStore = defineStore("game", () => {
       }))
 
     // Force reactivity
+  }
+
+  // Add new function
+  function canModifyGameState() {
+    if (!multiplayer.value) return true
+
+    if (multiplayer.value.role === "host") {
+      return gameState.value.currentPlayer === 0
+    } else {
+      return gameState.value.currentPlayer === 1
+    }
+  }
+
+  // Add new function
+  function updateJoiningPlayerName(name: string) {
+    if (!multiplayer.value || multiplayer.value.role !== "join") return
+
+    const code = multiplayer.value.code
+    updateGameState(code, {
+      "players/1/name": name,
+    })
   }
 
   // Roll callback function for animations
@@ -1381,9 +1381,9 @@ export const useGameStore = defineStore("game", () => {
     if (multiplayer.value && multiplayer.value.unbind)
       multiplayer.value.unbind()
     multiplayer.value = { code, role: "host" }
-    
+
     setGameState(code, gameState.value)
-    
+
     const stop = watch(
       gameState,
       (val) => {

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,5 +1,10 @@
 import { initializeApp } from "firebase/app"
-import { getDatabase, ref, set, remove } from "firebase/database"
+import { getDatabase, ref, get, set, remove, update } from "firebase/database"
+
+// Add new function
+export function updateGameState(code: string, updates: any) {
+  return update(getGameStateRef(code), updates)
+}
 import { useDatabaseObject } from "vuefire"
 
 export const firebaseApp = initializeApp({

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from "firebase/app"
-import { getDatabase, ref, get, set, remove, update } from "firebase/database"
+import { getDatabase, ref, set, remove, update } from "firebase/database"
 
 // Add new function
 export function updateGameState(code: string, updates: any) {


### PR DESCRIPTION
This PR enhances multiplayer game state management with the following changes:

- Added `updateGameState` function to Firebase utils for partial state updates
- Implemented `canModifyGameState` to control when players can modify game state
- Added `updateJoiningPlayerName` function to handle player name updates more efficiently
- Updated host multiplayer game logic to respect state modification rules
- Simplified joining player name update in GameMenu.vue

These changes improve the multiplayer experience by:
- Preventing unauthorized state modifications
- Making player name updates more efficient
- Reducing unnecessary full state updates
- Adding better control over game state modifications